### PR TITLE
优化了“设为壁纸”功能，并为之添加了部分翻译资源。

### DIFF
--- a/PixivFSUWP/BigImage.xaml
+++ b/PixivFSUWP/BigImage.xaml
@@ -37,7 +37,7 @@
                     <InkToolbarStencilButton/>
                 </InkToolbar>
             </CommandBar.Content>
-            <AppBarButton x:Name="btnSetWallpaper" Icon="SetLockScreen" x:Uid="SetWallpaper" Label="设置为壁纸" Click="btnSetWallpaper_Click"/>
+            <AppBarButton x:Name="btnSetWallpaper" Icon="SetLockScreen" x:Uid="SetWallpaper" Click="btnSetWallpaper_Click" />
             <AppBarButton x:Name="btnSaveImage" Icon="Save" x:Uid="SaveImage" Click="BtnSaveImage_Click"/>
             <AppBarToggleButton x:Name="btnDraw" Icon="Edit" x:Uid="Draw" Unchecked="BtnDraw_Unchecked" Checked="BtnDraw_Checked"/>
         </CommandBar>

--- a/PixivFSUWP/MultilingualResources/PixivFSUWP.ja.xlf
+++ b/PixivFSUWP/MultilingualResources/PixivFSUWP.ja.xlf
@@ -825,6 +825,26 @@ Do you want to disable them?</target>
           <target state="new">Download Manager</target>
           <note from="MultilingualBuild" annotates="source" priority="2">NavigationViewItemHeader</note>
         </trans-unit>
+        <trans-unit id="WallpaperFailedPlain" translate="yes" xml:space="preserve">
+          <source>Failed to change wallpaper</source>
+          <target state="translated">壁紙が変更できません</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
+        <trans-unit id="WallpaperNotSupportPlain" translate="yes" xml:space="preserve">
+          <source>Your device does not support changing the wallpaper</source>
+          <target state="translated">お使いのデバイスは壁紙の変更をサポートしていません</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
+        <trans-unit id="WallpaperSuccessPlain" translate="yes" xml:space="preserve">
+          <source>Wallpaper changed</source>
+          <target state="translated">壁紙を変更しました</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
+        <trans-unit id="SetWallpaper.Label" translate="yes" xml:space="preserve">
+          <source>Set as Wallpaper</source>
+          <target state="translated">壁紙に設定する</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PixivFSUWP/MultilingualResources/PixivFSUWP.zh-Hans.xlf
+++ b/PixivFSUWP/MultilingualResources/PixivFSUWP.zh-Hans.xlf
@@ -825,6 +825,26 @@ Do you want to disable them?</source>
           <target state="new">Download Manager</target>
           <note from="MultilingualBuild" annotates="source" priority="2">NavigationViewItemHeader</note>
         </trans-unit>
+        <trans-unit id="WallpaperFailedPlain" translate="yes" xml:space="preserve">
+          <source>Failed to change wallpaper</source>
+          <target state="translated">更换壁纸失败</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
+        <trans-unit id="WallpaperNotSupportPlain" translate="yes" xml:space="preserve">
+          <source>Your device does not support changing the wallpaper</source>
+          <target state="translated">您的设备不支持更换壁纸</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
+        <trans-unit id="WallpaperSuccessPlain" translate="yes" xml:space="preserve">
+          <source>Wallpaper changed</source>
+          <target state="translated">壁纸已更换</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
+        <trans-unit id="SetWallpaper.Label" translate="yes" xml:space="preserve">
+          <source>Set as Wallpaper</source>
+          <target state="translated">设为壁纸</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PixivFSUWP/MultilingualResources/PixivFSUWP.zh-Hant.xlf
+++ b/PixivFSUWP/MultilingualResources/PixivFSUWP.zh-Hant.xlf
@@ -813,6 +813,26 @@ Do you want to disable them?</source>
           <target state="new">Download Manager</target>
           <note from="MultilingualBuild" annotates="source" priority="2">NavigationViewItemHeader</note>
         </trans-unit>
+        <trans-unit id="WallpaperFailedPlain" translate="yes" xml:space="preserve">
+          <source>Failed to change wallpaper</source>
+          <target state="new">Failed to change wallpaper</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
+        <trans-unit id="WallpaperNotSupportPlain" translate="yes" xml:space="preserve">
+          <source>Your device does not support changing the wallpaper</source>
+          <target state="new">Your device does not support changing the wallpaper</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
+        <trans-unit id="WallpaperSuccessPlain" translate="yes" xml:space="preserve">
+          <source>Wallpaper changed</source>
+          <target state="new">Wallpaper changed</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
+        <trans-unit id="SetWallpaper.Label" translate="yes" xml:space="preserve">
+          <source>Set as Wallpaper</source>
+          <target state="new">Set as Wallpaper</target>
+          <note from="MultilingualBuild" annotates="source" priority="2">PlainText</note>
+        </trans-unit>
       </group>
     </body>
   </file>

--- a/PixivFSUWP/Strings/en/Resources.resw
+++ b/PixivFSUWP/Strings/en/Resources.resw
@@ -666,6 +666,10 @@ Do you want to disable them?</value>
     <value>Settings</value>
     <comment>PlainText</comment>
   </data>
+  <data name="SetWallpaper.Label" xml:space="preserve">
+    <value>Set as Wallpaper</value>
+    <comment>PlainText</comment>
+  </data>
   <data name="Sex.Text" xml:space="preserve">
     <value>Sex</value>
     <comment>TextBlock</comment>
@@ -733,6 +737,18 @@ Do you want to disable them?</value>
   <data name="VersionInfo.Text" xml:space="preserve">
     <value>Version information</value>
     <comment>TextBlock</comment>
+  </data>
+  <data name="WallpaperFailedPlain" xml:space="preserve">
+    <value>Failed to change wallpaper</value>
+    <comment>PlainText</comment>
+  </data>
+  <data name="WallpaperNotSupportPlain" xml:space="preserve">
+    <value>Your device does not support changing the wallpaper</value>
+    <comment>PlainText</comment>
+  </data>
+  <data name="WallpaperSuccessPlain" xml:space="preserve">
+    <value>Wallpaper changed</value>
+    <comment>PlainText</comment>
   </data>
   <data name="Work.Text" xml:space="preserve">
     <value>Works</value>

--- a/PixivFSUWP/Strings/ja/Resources.resw
+++ b/PixivFSUWP/Strings/ja/Resources.resw
@@ -25,7 +25,7 @@
     <comment>TextBlock</comment>
   </data>
   <data name="BookmarkDeleteFailedPlain" xml:space="preserve">
-    <value>ブックマークから「{0}」を削除できません</value>
+    <value>「{0}」をブックマークから解除できません</value>
     <comment>PlainText</comment>
   </data>
   <data name="Bookmarked.Content" xml:space="preserve">
@@ -53,7 +53,7 @@
     <comment>PlainText</comment>
   </data>
   <data name="Chair.Text" xml:space="preserve">
-    <value>チェア</value>
+    <value>椅子</value>
     <comment>TextBlock</comment>
   </data>
   <data name="CommentsPlain" xml:space="preserve">
@@ -77,11 +77,11 @@
     <comment>ComboBoxItem</comment>
   </data>
   <data name="DeleteBookmarkPlain" xml:space="preserve">
-    <value>ブックマーク削除</value>
+    <value>ブックマーク解除</value>
     <comment>PlainText</comment>
   </data>
   <data name="DeletedBookmarkPlain" xml:space="preserve">
-    <value>ブックマークから「{0}」を削除しました</value>
+    <value>「{0}」をブックマークから解除しました</value>
     <comment>PlainText</comment>
   </data>
   <data name="Desk.Text" xml:space="preserve">
@@ -173,7 +173,7 @@
     <comment>PlainText</comment>
   </data>
   <data name="LoadingStatusPlain" xml:space="preserve">
-    <value>{0}/{1} を読み込む中</value>
+    <value>{0}/{1}を読み込む中</value>
     <comment>PlainText</comment>
   </data>
   <data name="LoggingIn.Text" xml:space="preserve">
@@ -189,7 +189,7 @@
     <comment>TextBlock</comment>
   </data>
   <data name="LoginFailed.Content" xml:space="preserve">
-    <value>ログインできません。トラブルシューティングを行うか、もう一度やり直してください。</value>
+    <value>ログインできません。トラブルシューティングを行い、もう一度やり直してください。</value>
     <comment>Button</comment>
   </data>
   <data name="Logout.Content" xml:space="preserve">
@@ -197,7 +197,7 @@
     <comment>Button</comment>
   </data>
   <data name="LogoutWarning.Text" xml:space="preserve">
-    <value>*すべでのWindowsデバイスからログアウトします</value>
+    <value>*すべでのWindowsデバイスからログイン解除します</value>
     <comment>TextBlock</comment>
   </data>
   <data name="MalePlain" xml:space="preserve">
@@ -225,7 +225,7 @@
     <comment>PlainText</comment>
   </data>
   <data name="NoInkPlain" xml:space="preserve">
-    <value>保存するインクがありません</value>
+    <value>保存できるインクがありません</value>
     <comment>PlainText</comment>
   </data>
   <data name="NotBookmarked.Text" xml:space="preserve">
@@ -249,7 +249,7 @@
     <comment>PlainText</comment>
   </data>
   <data name="PageInfoPlain" xml:space="preserve">
-    <value>画像数: {0}</value>
+    <value>画像数: {0}。 クリックまたはタップして全画像モードに。</value>
     <comment>PlainText</comment>
   </data>
   <data name="PartiallyMatchTag.Content" xml:space="preserve">
@@ -557,40 +557,24 @@
     <comment>TextBlock</comment>
   </data>
   <data name="ExperimentalWarningPlain" xml:space="preserve">
-    <value>実験的な機能が有効になっています、安定性問題が発生する可能性があります。
-無効にしますか？</value>
+    <value>You have experimental features enabled. They may cause stability issues.
+Do you want to disable them?</value>
     <comment>PlainText</comment>
   </data>
-  <data name="ColorTheme.Text" xml:space="preserve">
-    <value>色</value>
-    <comment>TextBlock</comment>
-  </data>
-  <data name="DarkColorTheme.Content" xml:space="preserve">
-    <value>濃色</value>
-    <comment>ComboBoxItem</comment>
-  </data>
-  <data name="DefaultColorTheme.Content" xml:space="preserve">
-    <value>Windows モードを使用</value>
-    <comment>ComboBoxItem</comment>
-  </data>
-  <data name="LightColorTheme.Content" xml:space="preserve">
-    <value>淡色</value>
-    <comment>ComboBoxItem</comment>
-  </data>
-  <data name="RestartApplyColorTheme" xml:space="preserve">
-    <value>アプリを再起動して有効にする</value>
+  <data name="WallpaperFailedPlain" xml:space="preserve">
+    <value>壁紙が変更できません</value>
     <comment>PlainText</comment>
   </data>
-  <data name="ReleasedID" xml:space="preserve">
-    <value>パッケージ：</value>
+  <data name="WallpaperNotSupportPlain" xml:space="preserve">
+    <value>お使いのデバイスは壁紙の変更をサポートしていません</value>
     <comment>PlainText</comment>
   </data>
-  <data name="ReleasedTime" xml:space="preserve">
-    <value>時刻：</value>
+  <data name="WallpaperSuccessPlain" xml:space="preserve">
+    <value>壁紙を変更しました</value>
     <comment>PlainText</comment>
   </data>
-  <data name="ReleasedVersion" xml:space="preserve">
-    <value>バージョン：</value>
+  <data name="SetWallpaper.Label" xml:space="preserve">
+    <value>壁紙に設定する</value>
     <comment>PlainText</comment>
   </data>
 </root>

--- a/PixivFSUWP/Strings/zh-Hans/Resources.resw
+++ b/PixivFSUWP/Strings/zh-Hans/Resources.resw
@@ -641,4 +641,20 @@
     <value>当然</value>
     <comment>PlainText (❌Unworkable)</comment>
   </data>
+  <data name="WallpaperFailedPlain" xml:space="preserve">
+    <value>更换壁纸失败</value>
+    <comment>PlainText</comment>
+  </data>
+  <data name="WallpaperNotSupportPlain" xml:space="preserve">
+    <value>您的设备不支持更换壁纸</value>
+    <comment>PlainText</comment>
+  </data>
+  <data name="WallpaperSuccessPlain" xml:space="preserve">
+    <value>壁纸已更换</value>
+    <comment>PlainText</comment>
+  </data>
+  <data name="SetWallpaper.Label" xml:space="preserve">
+    <value>设为壁纸</value>
+    <comment>PlainText</comment>
+  </data>
 </root>


### PR DESCRIPTION
原本的“设为壁纸”功能仅仅是将IllustDetailPage中ImageList集合的第一张设置为壁纸。现改为将用户打开的BigImage的插画设为壁纸。